### PR TITLE
feat: product compare

### DIFF
--- a/src/main/java/com/project/savingbee/common/repository/DepositInterestRatesRepository.java
+++ b/src/main/java/com/project/savingbee/common/repository/DepositInterestRatesRepository.java
@@ -40,4 +40,10 @@ public interface DepositInterestRatesRepository extends JpaRepository<DepositInt
   // 알람 후보 수집용(금리 옵션 테이블에서 since 이후 변경된 상품 코드 목록)
   @Query("select distinct r.finPrdtCd from DepositInterestRates r where r.updatedAt > :since")
   List<String> findDistinctFinPrdtCdUpdatedAfter(@Param("since") LocalDateTime since);
+
+  // 예치 기간이 일치한 금리 정보 조회(상품코드 순)
+  List<DepositInterestRates> findAllBySaveTrmOrderByFinPrdtCd(Integer saveTrm);
+
+  // 상품코드 + 예치 기간으로 두 상품 정보 조회(상품 비교용)
+  List<DepositInterestRates> findAllByFinPrdtCdInAndSaveTrm(List<String> ids, Integer saveTrm);
 }

--- a/src/main/java/com/project/savingbee/common/repository/SavingsInterestRatesRepository.java
+++ b/src/main/java/com/project/savingbee/common/repository/SavingsInterestRatesRepository.java
@@ -63,5 +63,11 @@ public interface SavingsInterestRatesRepository extends JpaRepository<SavingsInt
 
   // 알람 후보 수집용(금리 옵션 테이블에서 since 이후 변경된 상품 코드 목록)
   @Query("select distinct r.finPrdtCd from SavingsInterestRates r where r.updatedAt > :since")
-  List<String> findDistinctFinPrdtCdUpdatedAfter(@Param("since") LocalDateTime since); 
+  List<String> findDistinctFinPrdtCdUpdatedAfter(@Param("since") LocalDateTime since);
+
+  // 예치 기간이 일치한 금리 정보 조회(상품코드 순)
+  List<SavingsInterestRates> findAllBySaveTrmOrderByFinPrdtCd(Integer saveTrm);
+
+  // 상품코드 + 예치 기간으로 두 상품 정보 조회(상품 비교용)
+  List<SavingsInterestRates> findAllByFinPrdtCdInAndSaveTrm(List<String> ids, Integer saveTrm);
 }

--- a/src/main/java/com/project/savingbee/productCompare/controller/ProductCompareController.java
+++ b/src/main/java/com/project/savingbee/productCompare/controller/ProductCompareController.java
@@ -1,0 +1,37 @@
+package com.project.savingbee.productCompare.controller;
+
+import com.project.savingbee.productCompare.dto.CompareExecuteRequestDto;
+import com.project.savingbee.productCompare.dto.CompareRequestDto;
+import com.project.savingbee.productCompare.dto.CompareResponseDto;
+import com.project.savingbee.productCompare.dto.ProductInfoDto;
+import com.project.savingbee.productCompare.service.ProductCompareService;
+import jakarta.validation.Valid;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/compare")
+public class ProductCompareController {
+  ProductCompareService productCompareService;
+
+  // 원하는 조건의 상품 목록 가져오기(필터링)
+  @GetMapping
+  public List<ProductInfoDto> findFilteredProduct(
+      @Valid CompareRequestDto compareRequestDto) {
+
+    return productCompareService.findFilteredProducts(compareRequestDto);
+  }
+
+  // 선택한 두 상품 정보 비교
+  @PostMapping
+  public CompareResponseDto compareProduct(
+      @Valid @RequestBody CompareExecuteRequestDto compareExecuteRequestDto) {
+    return productCompareService.compareProducts(compareExecuteRequestDto);
+  }
+}

--- a/src/main/java/com/project/savingbee/productCompare/dto/CompareExecuteRequestDto.java
+++ b/src/main/java/com/project/savingbee/productCompare/dto/CompareExecuteRequestDto.java
@@ -1,0 +1,34 @@
+package com.project.savingbee.productCompare.dto;
+
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import java.math.BigDecimal;
+import java.util.List;
+import lombok.Getter;
+import lombok.Setter;
+import org.hibernate.validator.constraints.UniqueElements;
+
+@Getter
+@Setter
+public class CompareExecuteRequestDto {
+  @NotNull
+  @Size(min = 2, max = 2)
+  @UniqueElements // 중복 방지
+  private List<String> productIds;  // 선택한 두 상품의 상품코드
+
+  @NotNull
+  private String type;  // 예금(D) / 적금(S)
+
+  @NotNull
+  private BigDecimal amount;  // 예치금 / 월 납입금
+
+  @NotNull
+  private Integer termMonth;  // 예치 기간
+
+  @NotNull
+  private BigDecimal minRate; // 최소 이자율(%)
+
+  @NotNull
+  private String intrRateType;  // 단리(S) / 복리(M) / 상관없음(Any)
+
+}

--- a/src/main/java/com/project/savingbee/productCompare/dto/CompareRequestDto.java
+++ b/src/main/java/com/project/savingbee/productCompare/dto/CompareRequestDto.java
@@ -1,0 +1,25 @@
+package com.project.savingbee.productCompare.dto;
+
+import jakarta.validation.constraints.NotNull;
+import java.math.BigDecimal;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class CompareRequestDto {
+  @NotNull
+  private String type;  // 예금(D) / 적금(S)
+
+  @NotNull
+  private BigDecimal amount;  // 예치금 / 월 납입금
+
+  @NotNull
+  private Integer termMonth;  // 예치 기간
+
+  @NotNull
+  private BigDecimal minRate; // 최소 이자율(%)
+
+  @NotNull
+  private String intrRateType;  // 단리(S) / 복리(M) / 상관없음(Any)
+}

--- a/src/main/java/com/project/savingbee/productCompare/dto/CompareResponseDto.java
+++ b/src/main/java/com/project/savingbee/productCompare/dto/CompareResponseDto.java
@@ -1,0 +1,12 @@
+package com.project.savingbee.productCompare.dto;
+
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class CompareResponseDto {
+  private final List<ProductCompareInfosDto> info;  // 비교하는 두 상품 정보
+  private final String winner;  // 만기시 실수령액이 더 높은 쪽의 상품코드, 같을 경우 둘 다 null
+}

--- a/src/main/java/com/project/savingbee/productCompare/dto/ProductCompareInfosDto.java
+++ b/src/main/java/com/project/savingbee/productCompare/dto/ProductCompareInfosDto.java
@@ -1,0 +1,23 @@
+package com.project.savingbee.productCompare.dto;
+
+import java.math.BigDecimal;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder(toBuilder = true)
+public class ProductCompareInfosDto {
+  private final String productId; // 상품코드
+  private final String bankName;  // 금융회사명
+  private final String productName; // 상품명
+
+  private final BigDecimal intrRateBeforeTax; // 세전 이자율(%)
+  private final BigDecimal intrRateAfterTax;  // 세후 이자율(%)
+  private final BigDecimal highestPrefRate;  // 최고 우대금리(%)
+
+  private final long intrAfterTax; // 세후 이자(원)
+  private final long amountReceived; // 실수령액(원)
+  private boolean winner; // 실수령액이 더 높은 쪽이 true, 같을 경우 둘 다 false
+
+  private String intrRateType;  // 단리(S) / 복리(M)
+}

--- a/src/main/java/com/project/savingbee/productCompare/dto/ProductInfoDto.java
+++ b/src/main/java/com/project/savingbee/productCompare/dto/ProductInfoDto.java
@@ -1,0 +1,55 @@
+package com.project.savingbee.productCompare.dto;
+
+import com.project.savingbee.common.entity.DepositInterestRates;
+import com.project.savingbee.common.entity.DepositProducts;
+import com.project.savingbee.common.entity.SavingsInterestRates;
+import com.project.savingbee.common.entity.SavingsProducts;
+import java.math.BigDecimal;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class ProductInfoDto {
+  private final String productId; // 상품코드
+  private final String bankName;  // 금융회사명
+  private final String productName; // 상품명
+
+  private final BigDecimal intrRate;  // 기본금리
+  private final BigDecimal intrRate2;  // 우대금리
+
+  private Integer termMonth;  // 예치기간
+  private String intrRateType;  // 단리(S) / 복리(M)
+
+  // 예금 Dto 매핑
+  public static ProductInfoDto fromDeposit(DepositInterestRates rate) {
+    DepositProducts products = rate.getDepositProduct();
+
+    return ProductInfoDto.builder()
+        .productId(products.getFinPrdtCd())
+        .bankName(products.getFinancialCompany().getKorCoNm())
+        .productName(products.getFinPrdtNm())
+        .intrRate(rate.getIntrRate())
+        .intrRate2(rate.getIntrRate2())
+        .termMonth(rate.getSaveTrm())
+        .intrRateType(rate.getIntrRateType())
+        .build();
+  }
+
+  // 적금 Dto 매핑
+  public static ProductInfoDto fromSavings(SavingsInterestRates rate) {
+    SavingsProducts products = rate.getSavingsProduct();
+
+    return ProductInfoDto.builder()
+        .productId(products.getFinPrdtCd())
+        .bankName(products.getFinancialCompany().getKorCoNm())
+        .productName(products.getFinPrdtNm())
+        .intrRate(rate.getIntrRate())
+        .intrRate2(rate.getIntrRate2())
+        .termMonth(rate.getSaveTrm())
+        .intrRateType(rate.getIntrRateType())
+        .build();
+  }
+}

--- a/src/main/java/com/project/savingbee/productCompare/service/ProductCompareService.java
+++ b/src/main/java/com/project/savingbee/productCompare/service/ProductCompareService.java
@@ -1,0 +1,192 @@
+package com.project.savingbee.productCompare.service;
+
+import com.project.savingbee.common.entity.DepositInterestRates;
+import com.project.savingbee.common.entity.DepositProducts;
+import com.project.savingbee.common.entity.SavingsInterestRates;
+import com.project.savingbee.common.entity.SavingsProducts;
+import com.project.savingbee.common.repository.DepositInterestRatesRepository;
+import com.project.savingbee.common.repository.SavingsInterestRatesRepository;
+import com.project.savingbee.productCompare.dto.CompareExecuteRequestDto;
+import com.project.savingbee.productCompare.dto.CompareRequestDto;
+import com.project.savingbee.productCompare.dto.CompareResponseDto;
+import com.project.savingbee.productCompare.dto.ProductCompareInfosDto;
+import com.project.savingbee.productCompare.dto.ProductInfoDto;
+import com.project.savingbee.productCompare.util.CalcEngine;
+import com.project.savingbee.productCompare.util.CalcEngine.CalcResult;
+import java.math.BigDecimal;
+import java.util.Comparator;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true) // 읽기 전용
+public class ProductCompareService {
+  private final DepositInterestRatesRepository depositInterestRatesRepository;
+  private final SavingsInterestRatesRepository savingsInterestRatesRepository;
+
+  // 상품 필터링
+  public List<ProductInfoDto> findFilteredProducts(CompareRequestDto requestDto) {
+    return requestDto.getType().equals("D") ?
+        findDepositProducts(requestDto) : findSavingsProducts(requestDto);
+  }
+
+  // 예금 필터링
+  private List<ProductInfoDto> findDepositProducts(CompareRequestDto requestDto) {
+    // 예치 기간이 일치한 금리 정보 조회
+    List<DepositInterestRates> rates =
+        depositInterestRatesRepository.findAllBySaveTrmOrderByFinPrdtCd(requestDto.getTermMonth());
+
+    return rates.stream()
+        // 단리 / 복리 / 상관없음
+        .filter(r -> matchesIntrRateType(requestDto, r.getIntrRateType()))
+        // 최소 이자율(우대금리 기준)
+        .filter(r -> r.getIntrRate2().compareTo(requestDto.getMinRate()) >= 0)
+        // 예치금 범위
+        .filter(r -> ableDepositAmount(requestDto, r.getDepositProduct()))
+        .map(ProductInfoDto::fromDeposit)
+        .toList();
+  }
+
+  // 적금 필터링
+  private List<ProductInfoDto> findSavingsProducts(CompareRequestDto requestDto) {
+    // 예치 기간이 일치한 금리 정보 조회
+    List<SavingsInterestRates> rates =
+        savingsInterestRatesRepository.findAllBySaveTrmOrderByFinPrdtCd(requestDto.getTermMonth());
+
+    return rates.stream()
+        // 단리 / 복리 / 상관없음
+        .filter(r -> matchesIntrRateType(requestDto, r.getIntrRateType()))
+        // 최소 이자율(우대금리 기준)
+        .filter(r -> r.getIntrRate2().compareTo(requestDto.getMinRate()) >= 0)
+        // 월 납입금액 범위
+        .filter(r -> ableSavingsAmount(requestDto, r))
+        .map(ProductInfoDto::fromSavings)
+        .toList();
+  }
+
+  // 단리 / 복리 / 상관없음
+  private boolean matchesIntrRateType(CompareRequestDto requestDto, String intrRateType) {
+    if (requestDto.getIntrRateType().equals("Any")) {
+      return true;
+    }
+    return requestDto.getIntrRateType().equals(intrRateType);
+  }
+
+  // 최소 가입금액 <= 예치 금액 <= 최대 한도
+  private boolean ableDepositAmount(CompareRequestDto requestDto, DepositProducts product) {
+    BigDecimal amount = requestDto.getAmount();
+    return amount.compareTo(product.getMinAmount()) >= 0
+        && amount.compareTo(product.getMaxAmount()) <= 0;
+  }
+
+  // 최소 월 납입금액 <= 월 납입금액 <= 최대 월 납입금액
+  private boolean ableSavingsAmount(CompareRequestDto requestDto, SavingsInterestRates rate) {
+    BigDecimal amount = requestDto.getAmount();
+    return amount.compareTo(rate.getMonthlyLimitMin()) >= 0
+        && amount.compareTo(rate.getMonthlyLimitMax()) <= 0;
+  }
+
+  // 상품 비교
+  public CompareResponseDto compareProducts(CompareExecuteRequestDto requestDto) {
+    List<ProductCompareInfosDto> products = requestDto.getType().equals("D") ?
+        compareDeposit(requestDto) : compareSavings(requestDto);
+
+    // 입력 순서 유지 정렬(먼저 선택한 상품을 왼쪽에)
+    List<String> ids = requestDto.getProductIds();
+    products.sort(Comparator.comparingInt(p -> ids.indexOf(p.getProductId())));
+
+    long maxAmount = products.stream().mapToLong(ProductCompareInfosDto::getAmountReceived).max().orElse(0);
+    long winners = products.stream().filter(p -> p.getAmountReceived() == maxAmount).count();
+
+    // 실수령액이 같은 경우 winner -> 둘 다 false
+    products = products.stream().map(p ->
+        p.toBuilder().winner(winners == 1 && p.getAmountReceived() == maxAmount).build())
+        .toList();
+
+    String winnerId = (winners == 1)
+        ? products.stream().filter(ProductCompareInfosDto::isWinner)
+            .findFirst().map(ProductCompareInfosDto::getProductId).orElse(null)
+        : null;
+
+    return new CompareResponseDto(products, winnerId);
+  }
+
+  // 예금 상품 비교
+  private List<ProductCompareInfosDto> compareDeposit(CompareExecuteRequestDto requestDto) {
+    List<String> ids = requestDto.getProductIds();
+    int saveTrm = requestDto.getTermMonth();
+
+    // 상품코드와 예치 기간이 일치한 상품 목록
+    List<DepositInterestRates> rates =
+        depositInterestRatesRepository.findAllByFinPrdtCdInAndSaveTrm(ids, saveTrm);
+
+    // 두 상품이 모두 조회됐는지 체크
+    if (rates.size() != ids.size()) {
+      throw new IllegalArgumentException("Invalid productIds or termMonth.");
+    }
+
+    return rates.stream().map(r -> {
+      DepositProducts p = r.getDepositProduct();
+
+      String calcType = requestDto.getIntrRateType().equals("Any") ?
+          r.getIntrRateType() : requestDto.getIntrRateType();
+
+      // 세후 이자, 실수령액 계산
+      CalcResult c = CalcEngine.deposit(
+          requestDto.getAmount(), r.getIntrRate(), saveTrm, calcType);
+
+      return ProductCompareInfosDto.builder()
+          .productId(p.getFinPrdtCd())
+          .bankName(p.getFinancialCompany().getKorCoNm())
+          .productName(p.getFinPrdtNm())
+          .intrRateBeforeTax(r.getIntrRate2())
+          .intrRateAfterTax(r.getIntrRate())
+          .highestPrefRate(r.getIntrRate2())
+          .intrRateAfterTax(c.getAfterTaxInterest())
+          .amountReceived(c.getAmountReceived())
+          .intrRateType(r.getIntrRateType())
+          .build();
+    }).toList();
+  }
+
+  // 적금 상품 비교
+  private List<ProductCompareInfosDto> compareSavings(CompareExecuteRequestDto requestDto) {
+
+    List<String> ids = requestDto.getProductIds();
+    int saveTrm = requestDto.getTermMonth();
+
+    List<SavingsInterestRates> rates =
+        savingsInterestRatesRepository.findAllByFinPrdtCdInAndSaveTrm(ids, saveTrm);
+
+    // 두 상품이 모두 조회됐는지 체크
+    if (rates.size() != ids.size()) {
+      throw new IllegalArgumentException("Invalid productIds or termMonth.");
+    }
+
+    return rates.stream().map(r -> {
+      SavingsProducts p = r.getSavingsProduct();
+
+      String calcType = requestDto.getIntrRateType().equals("Any") ?
+          r.getIntrRateType() : requestDto.getIntrRateType();
+
+      // 세후 이자, 실수령액 계산
+      CalcResult c = CalcEngine.savings(
+          requestDto.getAmount(), r.getIntrRate(), saveTrm, calcType);
+
+      return ProductCompareInfosDto.builder()
+          .productId(p.getFinPrdtCd())
+          .bankName(p.getFinancialCompany().getKorCoNm())
+          .productName(p.getFinPrdtNm())
+          .intrRateBeforeTax(r.getIntrRate2())
+          .intrRateAfterTax(r.getIntrRate())
+          .highestPrefRate(r.getIntrRate2())
+          .intrRateAfterTax(c.getAfterTaxInterest())
+          .amountReceived(c.getAmountReceived())
+          .intrRateType(r.getIntrRateType())
+          .build();
+    }).toList();
+  }
+}

--- a/src/main/java/com/project/savingbee/productCompare/service/ProductCompareService.java
+++ b/src/main/java/com/project/savingbee/productCompare/service/ProductCompareService.java
@@ -14,6 +14,7 @@ import com.project.savingbee.productCompare.dto.ProductInfoDto;
 import com.project.savingbee.productCompare.util.CalcEngine;
 import com.project.savingbee.productCompare.util.CalcEngine.CalcResult;
 import java.math.BigDecimal;
+import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -91,8 +92,8 @@ public class ProductCompareService {
 
   // 상품 비교
   public CompareResponseDto compareProducts(CompareExecuteRequestDto requestDto) {
-    List<ProductCompareInfosDto> products = requestDto.getType().equals("D") ?
-        compareDeposit(requestDto) : compareSavings(requestDto);
+    List<ProductCompareInfosDto> products = new ArrayList<>(
+        requestDto.getType().equals("D") ? compareDeposit(requestDto) : compareSavings(requestDto));
 
     // 입력 순서 유지 정렬(먼저 선택한 상품을 왼쪽에)
     List<String> ids = requestDto.getProductIds();

--- a/src/main/java/com/project/savingbee/productCompare/util/CalcEngine.java
+++ b/src/main/java/com/project/savingbee/productCompare/util/CalcEngine.java
@@ -1,0 +1,82 @@
+package com.project.savingbee.productCompare.util;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+// 세후 이자, 실수령액 계산
+public final class CalcEngine {
+  /**
+   * 예금 만기시 실수령액 계산
+   * @param amount 예치금액
+   * @param rate 세후 이자율
+   * @param termMonth 예치기간
+   * @param intrRateType 이자계산방식(단리/복리)
+   */
+  public static CalcResult deposit(
+      BigDecimal amount, BigDecimal rate, int termMonth, String intrRateType) {
+
+    BigDecimal A = amount.setScale(0, RoundingMode.DOWN); // 예치금(원)
+    BigDecimal R = rate.movePointLeft(2); // % -> 소수
+    BigDecimal I = R.divide(new BigDecimal("12"), 10, RoundingMode.HALF_UP);
+
+    BigDecimal interest = intrRateType.equals("S")
+        ? A.multiply(R).multiply(BigDecimal.valueOf(termMonth)
+            .divide(BigDecimal.valueOf(12), 10, RoundingMode.HALF_UP))
+        : A.multiply(BigDecimal.ONE.add(I).pow(termMonth).subtract(BigDecimal.ONE));
+
+    BigDecimal afterTaxInterest = interest.setScale(0, RoundingMode.DOWN);
+    long amountReceived = A.longValue() + afterTaxInterest.longValue();
+
+    return new CalcResult(afterTaxInterest, amountReceived);
+  }
+
+  /**
+   * 적금 만기시 실수령액 계산
+   * @param amount 월 납입금액
+   * @param rate 세후 이자율
+   * @param termMonth 예치기간
+   * @param intrRateType 이자계산방식(단리/복리)
+   */
+  public static CalcResult savings(
+      BigDecimal amount, BigDecimal rate, int termMonth, String intrRateType) {
+
+    BigDecimal A = amount.setScale(0, RoundingMode.DOWN);
+    BigDecimal R = rate.movePointLeft(2);
+    BigDecimal I = R.divide(BigDecimal.valueOf(12), 10, RoundingMode.HALF_UP);
+
+    BigDecimal totalAmount = A.multiply(BigDecimal.valueOf(termMonth)); // 총 납입원금
+
+    BigDecimal interest;
+
+    if (intrRateType.equals("S")) {
+      // A * I * n(n+1)/2
+      interest = A.multiply(I).multiply(BigDecimal.valueOf(termMonth))
+          .multiply(BigDecimal.valueOf(termMonth + 1))
+          .divide(BigDecimal.valueOf(2), 10, RoundingMode.HALF_UP);
+    } else {
+      if (I.signum() == 0) {
+        interest = BigDecimal.ZERO;
+      } else {
+        // A * ((1+I)^n-1) / I
+        interest = A.multiply(BigDecimal.ONE.add(I).pow(termMonth).subtract(BigDecimal.ONE))
+            .divide(I, 10, RoundingMode.HALF_UP).subtract(totalAmount);
+      }
+    }
+
+    BigDecimal afterTaxInterest = interest.setScale(0, RoundingMode.DOWN);
+    long amountReceived =
+        totalAmount.setScale(0, RoundingMode.DOWN).longValue() + afterTaxInterest.longValue();
+
+    return new CalcResult(afterTaxInterest, amountReceived);
+  }
+
+  @Getter
+  @AllArgsConstructor
+  public static class CalcResult {
+    private final BigDecimal afterTaxInterest;  // 세후 이자
+    private final long amountReceived;  // 실수령액
+  }
+
+}

--- a/src/test/java/com/project/savingbee/productCompare/ProductCompareServiceFilteringTest.java
+++ b/src/test/java/com/project/savingbee/productCompare/ProductCompareServiceFilteringTest.java
@@ -1,0 +1,249 @@
+package com.project.savingbee.productCompare;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+
+import com.project.savingbee.common.entity.DepositInterestRates;
+import com.project.savingbee.common.entity.DepositProducts;
+import com.project.savingbee.common.entity.SavingsInterestRates;
+import com.project.savingbee.common.repository.DepositInterestRatesRepository;
+import com.project.savingbee.common.repository.SavingsInterestRatesRepository;
+import com.project.savingbee.productCompare.dto.CompareRequestDto;
+import com.project.savingbee.productCompare.dto.ProductInfoDto;
+import com.project.savingbee.productCompare.service.ProductCompareService;
+import java.math.BigDecimal;
+import java.util.Arrays;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Answers;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class ProductCompareServiceFilteringTest {
+  @Mock
+  private DepositInterestRatesRepository depositInterestRatesRepository;
+  @Mock
+  private SavingsInterestRatesRepository savingsInterestRatesRepository;
+
+  @InjectMocks
+  private ProductCompareService productCompareService;
+
+  private CompareRequestDto requestDto(String type, String amount, int term, String minRate, String intrType) {
+    CompareRequestDto requestDto = new CompareRequestDto();
+    requestDto.setType(type); // D / S
+    requestDto.setAmount(new BigDecimal(amount));
+    requestDto.setTermMonth(term);
+    requestDto.setMinRate(new BigDecimal(minRate));
+    requestDto.setIntrRateType(intrType); // S / M / Any
+    return requestDto;
+  }
+
+  // 필터링 통과하는 케이스 용
+  private DepositInterestRates depositRateMapped(
+      String prdtCd, String intr2, String intrType,
+      String minAmt, String maxAmt, int term) {
+
+    DepositInterestRates r = mock(DepositInterestRates.class, Answers.RETURNS_DEEP_STUBS);
+    DepositProducts p = r.getDepositProduct();
+
+    given(r.getDepositProduct()).willReturn(p);
+
+    given(p.getFinPrdtCd()).willReturn(prdtCd);
+    given(p.getMinAmount()).willReturn(new BigDecimal(minAmt));
+    given(p.getMaxAmount()).willReturn(new BigDecimal(maxAmt));
+
+    given(r.getIntrRate2()).willReturn(new BigDecimal(intr2));
+    given(r.getIntrRateType()).willReturn(intrType);
+    given(r.getIntrRate()).willReturn(new BigDecimal("2.00"));
+    given(r.getSaveTrm()).willReturn(term);
+    return r;
+  }
+
+  // 타입에서 탈락하는 케이스 용
+  private DepositInterestRates depositRateTypeOnly(String intrType) {
+    DepositInterestRates r = mock(DepositInterestRates.class);
+    given(r.getIntrRateType()).willReturn(intrType);
+    return r;
+  }
+
+  // 최소 이자율에서 탈락하는 케이스 용
+  private DepositInterestRates depositRateMinOnly(String intr2, String intrType) {
+    DepositInterestRates r = mock(DepositInterestRates.class);
+    given(r.getIntrRateType()).willReturn(intrType);
+    given(r.getIntrRate2()).willReturn(new BigDecimal(intr2));
+    return r;
+  }
+
+  // 금액에서 탈락하는 케이스 용
+  private DepositInterestRates depositRateWithAmountOnly(String intr2, String intrType,
+      String minAmt, String maxAmt) {
+    DepositInterestRates r = mock(DepositInterestRates.class, Answers.RETURNS_DEEP_STUBS);
+    given(r.getIntrRateType()).willReturn(intrType);
+    given(r.getIntrRate2()).willReturn(new BigDecimal(intr2));
+    given(r.getDepositProduct().getMinAmount()).willReturn(new BigDecimal(minAmt));
+    given(r.getDepositProduct().getMaxAmount()).willReturn(new BigDecimal(maxAmt));
+    return r;
+  }
+
+  // 필터링 탈락하는 케이스 용
+  private SavingsInterestRates savingsRateFilter(
+      String prdtCd, String intr2, String intrType,
+      String monthlyMin, String monthlyMax, int term) {
+
+    SavingsInterestRates r = mock(SavingsInterestRates.class, Answers.RETURNS_DEEP_STUBS);
+
+    given(r.getMonthlyLimitMin()).willReturn(new BigDecimal(monthlyMin));
+    given(r.getMonthlyLimitMax()).willReturn(new BigDecimal(monthlyMax));
+    given(r.getIntrRate2()).willReturn(new BigDecimal(intr2));
+    given(r.getIntrRateType()).willReturn(intrType);
+
+    return r;
+  }
+
+  // 필터링 통과하는 케이스 용
+  private SavingsInterestRates savingsRateMapped(
+      String prdtCd, String intr2, String intrType,
+      String monthlyMin, String monthlyMax, int term) {
+
+    SavingsInterestRates r = savingsRateFilter(prdtCd, intr2, intrType, monthlyMin, monthlyMax, term);
+
+    given(r.getSavingsProduct().getFinPrdtCd()).willReturn(prdtCd);
+    given(r.getIntrRate()).willReturn(new BigDecimal("2.00"));
+    given(r.getSaveTrm()).willReturn(term);
+
+    return r;
+  }
+
+  @Nested
+  @DisplayName("예금 필터링")
+  class DepositFiltering {
+
+    @Test
+    @DisplayName("단리(S), 최소 이자율, 예치금액 범위 필터링")
+    void depositFilter() {
+        // given
+      int term = 12;
+      DepositInterestRates r1 = depositRateMapped("A", "3.40", "S", "1000000", "5000000", term); // 통과
+      DepositInterestRates r2 = depositRateMapped("B", "3.20", "S", "1000000", "5000000", term); // 통과
+      DepositInterestRates r3 = depositRateTypeOnly("M"); // 타입 불일치
+      DepositInterestRates r4 = depositRateMinOnly("2.90", "S"); // 금리 미달
+      DepositInterestRates r5 = depositRateWithAmountOnly("3.30", "S", "6000000", "10000000"); // 금액 범위 불일치
+
+      given(depositInterestRatesRepository.findAllBySaveTrmOrderByFinPrdtCd(term))
+          .willReturn(Arrays.asList(r1, r2, r3, r4, r5));
+
+      CompareRequestDto dto = requestDto("D", "3000000", term, "3.00", "S");
+
+        // when
+      List<ProductInfoDto> result = productCompareService.findFilteredProducts(dto);
+
+        // then
+      then(depositInterestRatesRepository).should().findAllBySaveTrmOrderByFinPrdtCd(term);
+      assertThat(result).extracting(ProductInfoDto::getProductId)
+          .containsExactly("A", "B"); // 상품코드 순으로 정렬
+    }
+
+    @Test
+    @DisplayName("단리/복리 상관없음(Any)일 때")
+    void depositIntrRateTypeAny() {
+        // given
+      int term = 12;
+      DepositInterestRates r1 = depositRateMapped("A", "3.10", "S", "1000000", "5000000", term);
+      DepositInterestRates r2 = depositRateMapped("B", "3.20", "M", "1000000", "5000000", term);
+
+      given(depositInterestRatesRepository.findAllBySaveTrmOrderByFinPrdtCd(term))
+          .willReturn(Arrays.asList(r1, r2));
+
+      CompareRequestDto dto = requestDto("D", "2000000", term, "3.00", "Any");
+
+        // when
+      List<ProductInfoDto> result = productCompareService.findFilteredProducts(dto);
+
+        // then
+      assertThat(result).extracting(ProductInfoDto::getProductId)
+          .containsExactly("A", "B");
+    }
+
+    @Test
+    @DisplayName("예치금이 경계값일 때")
+    void depositAmountRangInclusive() {
+        // given
+      int term = 6;
+      DepositInterestRates rMin = depositRateMapped("MIN", "3.00", "S", "1000000", "5000000", term);
+      DepositInterestRates rMax = depositRateMapped("MAX", "3.10", "S", "1000000", "5000000", term);
+
+      given(depositInterestRatesRepository.findAllBySaveTrmOrderByFinPrdtCd(term))
+          .willReturn(Arrays.asList(rMin, rMax));
+
+        // when
+      CompareRequestDto minDto = requestDto("D", "1000000", term, "0.00", "S"); // min
+      CompareRequestDto maxDto = requestDto("D", "5000000", term, "0.00", "S"); // max
+
+      List<ProductInfoDto> atMin = productCompareService.findFilteredProducts(minDto);
+      List<ProductInfoDto> atMax = productCompareService.findFilteredProducts(maxDto);
+
+        // then
+      assertThat(atMin).extracting(ProductInfoDto::getProductId).containsExactly("MIN", "MAX");
+      assertThat(atMax).extracting(ProductInfoDto::getProductId).containsExactly("MIN", "MAX");
+    }
+  }
+
+  @Nested
+  @DisplayName("적금 필터링")
+  class SavingsFiltering {
+
+    @Test
+    @DisplayName("월 납입금액이 월 한도 범위에 있을 때(경계 포함)")
+    void savingsMonthlyAmountRangeInclusive() {
+        // given
+      int term = 24;
+      SavingsInterestRates r1 = savingsRateMapped("S1", "4.00", "S", "100000", "500000", term);
+      SavingsInterestRates r2 = savingsRateMapped("S2", "3.50", "S", "300000", "700000", term);
+
+      given(savingsInterestRatesRepository.findAllBySaveTrmOrderByFinPrdtCd(term))
+          .willReturn(Arrays.asList(r1, r2));
+
+        // when
+      CompareRequestDto dto1 = requestDto("S", "100000", term, "0.00", "Any"); // min
+      CompareRequestDto dto2 = requestDto("S", "700000", term, "0.00", "Any"); // max
+
+      List<ProductInfoDto> atLower = productCompareService.findFilteredProducts(dto1);
+      List<ProductInfoDto> atUpper = productCompareService.findFilteredProducts(dto2);
+
+        // then
+      then(savingsInterestRatesRepository).should(times(2)).findAllBySaveTrmOrderByFinPrdtCd(term);
+      assertThat(atLower).extracting(ProductInfoDto::getProductId).containsExactly("S1");
+      assertThat(atUpper).extracting(ProductInfoDto::getProductId).containsExactly("S2");
+    }
+
+    @Test
+    @DisplayName("복리(M), 최소 이자율 필터링")
+    void savingsFilter() {
+        // given
+      int term = 12;
+      SavingsInterestRates mOk = savingsRateMapped("OK", "4.10", "M", "1", "99999999", term); // 통과
+      SavingsInterestRates mLow = savingsRateFilter("LOW", "3.00", "M", "1", "99999999", term); // 금리 미달
+      SavingsInterestRates sType = savingsRateFilter("S", "5.00", "S", "1", "99999999", term);  // 타입 불일치
+
+      given(savingsInterestRatesRepository.findAllBySaveTrmOrderByFinPrdtCd(term))
+          .willReturn(Arrays.asList(mOk, mLow, sType));
+
+      CompareRequestDto dto = requestDto("S", "10000", term, "4.00", "M");
+
+        // when
+      List<ProductInfoDto> result = productCompareService.findFilteredProducts(dto);
+
+        // then
+      assertThat(result).extracting(ProductInfoDto::getProductId)
+          .containsExactly("OK");
+    }
+  }
+}

--- a/src/test/java/com/project/savingbee/productCompare/ProductCompareServiceTest.java
+++ b/src/test/java/com/project/savingbee/productCompare/ProductCompareServiceTest.java
@@ -1,0 +1,244 @@
+package com.project.savingbee.productCompare;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.mock;
+
+import com.project.savingbee.common.entity.DepositInterestRates;
+import com.project.savingbee.common.entity.SavingsInterestRates;
+import com.project.savingbee.common.repository.DepositInterestRatesRepository;
+import com.project.savingbee.common.repository.SavingsInterestRatesRepository;
+import com.project.savingbee.productCompare.dto.CompareExecuteRequestDto;
+import com.project.savingbee.productCompare.dto.CompareResponseDto;
+import com.project.savingbee.productCompare.dto.ProductCompareInfosDto;
+import com.project.savingbee.productCompare.service.ProductCompareService;
+import java.math.BigDecimal;
+import java.util.Arrays;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Answers;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class ProductCompareServiceTest {
+  @Mock
+  private DepositInterestRatesRepository depositInterestRatesRepository;
+  @Mock
+  private SavingsInterestRatesRepository savingsInterestRatesRepository;
+
+  @InjectMocks
+  private ProductCompareService productCompareService;
+
+  private CompareExecuteRequestDto depositRequestDto(List<String> ids, String amount, int term, String intrType) {
+    CompareExecuteRequestDto requestDto = new CompareExecuteRequestDto();
+    requestDto.setProductIds(ids);
+    requestDto.setType("D");
+    requestDto.setAmount(new BigDecimal(amount));
+    requestDto.setTermMonth(term);
+    requestDto.setMinRate(new BigDecimal("0.00"));
+    requestDto.setIntrRateType(intrType);
+    return requestDto;
+  }
+  private CompareExecuteRequestDto savingsRequestDto(List<String> ids, String amount, int term, String intrType) {
+    CompareExecuteRequestDto requestDto = new CompareExecuteRequestDto();
+    requestDto.setProductIds(ids);
+    requestDto.setType("S");
+    requestDto.setAmount(new BigDecimal(amount));
+    requestDto.setTermMonth(term);
+    requestDto.setMinRate(new BigDecimal("0.00"));
+    requestDto.setIntrRateType(intrType);
+    return requestDto;
+  }
+
+  private DepositInterestRates depositRate(String prdtCd, String bank, String name,
+      String intr, String intr2, String intrType) {
+    DepositInterestRates r = mock(DepositInterestRates.class, Answers.RETURNS_DEEP_STUBS);
+    // product
+    given(r.getDepositProduct().getFinPrdtCd()).willReturn(prdtCd);
+    given(r.getDepositProduct().getFinancialCompany().getKorCoNm()).willReturn(bank);
+    given(r.getDepositProduct().getFinPrdtNm()).willReturn(name);
+    // rates
+    given(r.getIntrRate()).willReturn(new BigDecimal(intr));   // 기본금리(세후 계산 입력)
+    given(r.getIntrRate2()).willReturn(new BigDecimal(intr2)); // 우대금리/표시용
+    given(r.getIntrRateType()).willReturn(intrType);
+    return r;
+  }
+
+  private SavingsInterestRates savingsRate(String prdtCd, String bank, String name,
+      String intr, String intr2, String intrType) {
+    SavingsInterestRates r = mock(SavingsInterestRates.class, Answers.RETURNS_DEEP_STUBS);
+    // product
+    given(r.getSavingsProduct().getFinPrdtCd()).willReturn(prdtCd);
+    given(r.getSavingsProduct().getFinancialCompany().getKorCoNm()).willReturn(bank);
+    given(r.getSavingsProduct().getFinPrdtNm()).willReturn(name);
+    // rates
+    given(r.getIntrRate()).willReturn(new BigDecimal(intr));
+    given(r.getIntrRate2()).willReturn(new BigDecimal(intr2));
+    given(r.getIntrRateType()).willReturn(intrType);
+    return r;
+  }
+
+  @Nested
+  @DisplayName("예금 비교")
+  class DepositCompare {
+
+    @Test
+    @DisplayName("두 상품의 금리가 다를 때, 더 높은 금리가 winner. 입력 순서 유지 검증")
+    void depositWinnerAndPreserveInputOrder() {
+        // given
+      int term = 12;
+      DepositInterestRates A = depositRate("A", "은행A", "상품A", "3.10", "3.40", "S");
+      DepositInterestRates B = depositRate("B", "은행B", "상품B", "3.20", "3.50", "S");
+
+      // 레포지토리에서 역순으로 반환해도 서비스가 ids 순(사용자가 선택한 순서)으로 재정렬하는지 검증
+      given(
+          depositInterestRatesRepository.findAllByFinPrdtCdInAndSaveTrm(Arrays.asList("B","A"), term))
+          .willReturn(Arrays.asList(A, B));
+
+      CompareExecuteRequestDto requestDto = depositRequestDto(Arrays.asList("B","A"), "3000000", term, "S");
+
+        // when
+      CompareResponseDto responseDto = productCompareService.compareProducts(requestDto);
+
+        // then
+      then(depositInterestRatesRepository).should().findAllByFinPrdtCdInAndSaveTrm(Arrays.asList("B","A"), term);
+
+      // 입력 순서 유지(먼저 선택한 것이 앞쪽으로)
+      assertThat(responseDto.getInfo()).extracting(ProductCompareInfosDto::getProductId)
+          .containsExactly("B", "A");
+
+      // B 금리가 더 높으므로 수령액도 높아 winner = "B"
+      assertThat(responseDto.getWinner()).isEqualTo("B");
+      assertThat(responseDto.getInfo()).filteredOn(ProductCompareInfosDto::isWinner)
+          .extracting(ProductCompareInfosDto::getProductId)
+          .containsExactly("B");
+    }
+
+    @Test
+    @DisplayName("두 상품의 금리가 동일할 때(winner=null, isWinner=false)")
+    void depositSameResults() {
+        // given
+      int term = 12;
+      DepositInterestRates A = depositRate("A", "은행A", "상품A", "3.10", "3.40", "S");
+      DepositInterestRates B = depositRate("B", "은행B", "상품B", "3.10", "3.40", "S");
+
+      given(
+          depositInterestRatesRepository.findAllByFinPrdtCdInAndSaveTrm(Arrays.asList("A","B"), term))
+          .willReturn(Arrays.asList(A, B));
+
+      CompareExecuteRequestDto requestDto = depositRequestDto(Arrays.asList("A","B"), "3000000", term, "S");
+
+        // when
+      CompareResponseDto responseDto = productCompareService.compareProducts(requestDto);
+
+        // then
+      assertThat(responseDto.getWinner()).isNull();
+      assertThat(responseDto.getInfo()).extracting(ProductCompareInfosDto::isWinner)
+          .containsExactly(false, false);
+    }
+
+    @Test
+    @DisplayName("상품코드 반환 오류")
+    void depositInvalidIds() {
+        // given
+      int term = 12;
+      DepositInterestRates A = mock(DepositInterestRates.class);
+
+      given(
+          depositInterestRatesRepository.findAllByFinPrdtCdInAndSaveTrm(Arrays.asList("A","B"), term))
+          .willReturn(List.of(A)); // 부족하게 반환
+
+      CompareExecuteRequestDto requestDto = depositRequestDto(Arrays.asList("A","B"), "3000000", term, "S");
+
+        // when
+
+        // then
+      assertThatThrownBy(() -> productCompareService.compareProducts(requestDto))
+          .isInstanceOf(IllegalArgumentException.class)
+          .hasMessageContaining("Invalid productIds or termMonth");
+    }
+  }
+
+  @Nested
+  @DisplayName("적금 비교")
+  class SavingsCompare {
+
+    @Test
+    @DisplayName("두 상품의 금리가 다를 때, 더 높은 금리가 winner. 입력 순서 유지 검증")
+    void savingsWinnerAndPreserveInputOrder() {
+        // given
+      int term = 24;
+      SavingsInterestRates X = savingsRate("X", "은행X", "적금X", "4.00", "4.20", "S");
+      SavingsInterestRates Y = savingsRate("Y", "은행Y", "적금Y", "3.50", "3.70", "S");
+
+      given(
+          savingsInterestRatesRepository.findAllByFinPrdtCdInAndSaveTrm(Arrays.asList("Y","X"), term))
+          .willReturn(Arrays.asList(X, Y));
+
+      CompareExecuteRequestDto requestDto = savingsRequestDto(Arrays.asList("Y","X"), "100000", term, "S");
+
+        // when
+      CompareResponseDto responseDto = productCompareService.compareProducts(requestDto);
+
+        // then
+      then(savingsInterestRatesRepository).should().findAllByFinPrdtCdInAndSaveTrm(Arrays.asList("Y","X"), term);
+
+      // 입력 순서 유지(먼저 선택한 것이 앞쪽으로)
+      assertThat(responseDto.getInfo()).extracting(ProductCompareInfosDto::getProductId)
+          .containsExactly("Y", "X");
+      // X 금리가 더 높으므로 수령액도 높아 winner = "X"
+      assertThat(responseDto.getWinner()).isEqualTo("X");
+    }
+
+    @Test
+    @DisplayName("두 상품의 금리가 동일할 때(winner=null, isWinner=false)")
+    void savingsSameResults() {
+        // given
+      int term = 24;
+      SavingsInterestRates X = savingsRate("X", "은행X", "적금X", "3.50", "3.70", "S");
+      SavingsInterestRates Y = savingsRate("Y", "은행Y", "적금Y", "3.50", "3.70", "S");
+
+      given(
+          savingsInterestRatesRepository.findAllByFinPrdtCdInAndSaveTrm(Arrays.asList("Y","X"), term))
+          .willReturn(Arrays.asList(X, Y));
+
+      CompareExecuteRequestDto requestDto = savingsRequestDto(Arrays.asList("Y","X"), "100000", term, "S");
+
+      // when
+      CompareResponseDto responseDto = productCompareService.compareProducts(requestDto);
+
+      // then
+      assertThat(responseDto.getWinner()).isNull();
+      assertThat(responseDto.getInfo()).extracting(ProductCompareInfosDto::isWinner)
+          .containsExactly(false, false);
+    }
+
+    @Test
+    @DisplayName("상품코드 반환 오류")
+    void savingsInvalidIds() {
+        // given
+      int term = 24;
+      SavingsInterestRates X = mock(SavingsInterestRates.class);
+
+      given(
+          savingsInterestRatesRepository.findAllByFinPrdtCdInAndSaveTrm(Arrays.asList("X","Y"), term))
+          .willReturn(List.of(X));
+
+      CompareExecuteRequestDto requestDto = savingsRequestDto(Arrays.asList("X","Y"), "100000", term, "S");
+
+        // when
+
+        // then
+      assertThatThrownBy(() -> productCompareService.compareProducts(requestDto))
+          .isInstanceOf(IllegalArgumentException.class)
+          .hasMessageContaining("Invalid productIds or termMonth");
+    }
+  }
+}


### PR DESCRIPTION
<!-- PR 템플릿 틀입니다. 제가 다른 자료를 참고하여 임의로 작성한 부분이니 수정하셔서 사용하시면 될 것 같습니다! --> 
## 📝 계획
### 기존 상태
<!-- 코드 수정 전 기존 상태를 작성해주시면 됩니다. -->
- 알림 발송 기능 구현(이메일)
- 이벤트 상태 관리 클래스 추가
- 알림 발송 스케줄러 구현

### 변경 후 상태
<!-- 코드 수정 후 상태를 작성해주시면 됩니다. -->
- 상품 비교 기능 구현
- 테스트 코드 추가

## 💡PR에서 핵심적으로 변경된 사항
<!-- 이번 pr에서 핵심적으로 변경된 부분을 작성해주시면 됩니다. -->
- 상품 비교 기능 추가
- findFilteredProducts
  - 선택 조건으로 필터링 후 상품 목록 반환(상품 종류/금액/기간/최소 이자율/이자계산방식)
- compareProducts
  - 상품 목록 중 두 상품을 선택하여 비교
  - 비교 항목 - 금융회사명, 상품명, 세전/후 이자율(%), 최고 우대금리(%), 만기시 받을 수 있는 세후 이자 및 실수령액, 이자계산방식
  - 실수령액이 더 높은 쪽을 강조 표시
- CalcEngine
  - 설정한 조건(금액/기간)에 따라 세후 이자 및 실수령액을 계산

## 📢이외 추가 변경 부분 및 기타
<!-- 부가적으로 변경된 부분이나 추가적으로 생각하신 부분이 있다면 적어주세요. 
ex) 사용자 부분 수정하였는데 알람부분 충돌있는지 확인해야 할 것 같습니다. -->
- 상품의 세부 정보를 보여주는 기능도 있었으나, 상품의 상세정보 페이지로 넘어가는 방식으로 바뀌어서 빠졌습니다.
## ✅ 테스트
<!-- 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [X] 테스트 코드
- [ ] API 테스트 